### PR TITLE
Changed docker-compose file and db creation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# PipedriveEmployees
+# Pipedrive Employee and Tribe Info Web Application
+
+This web application provides information about Pipedrive's employees and tribes. It consists of two main pages: one for managing employee data and another for viewing tribe information. Users can add, update, and delete employee records on the first page, while the second page is read-only and displays details about tribes.
+
+## Getting Started
+
+### Prerequisites
+
+Before you begin, ensure you have the following prerequisites:
+
+- [Docker](https://www.docker.com/get-started) installed on your system.
+
+### Installation
+
+1. Clone the repository to your local machine:
+2. Build and start the application using Docker. First open Docker desktop application. Then run:
+
+`docker-compose build` and
+`docker-compose up`
+
+3. This command will build both the frontend (built with React) and backend containers and start the application. The webpage should be accessible at <http://localhost:3000>.
+If the webpage is not opened automatically, open your web browser and go to <http://localhost:3000> to access the application.
+
+## Usage
+
+The first page of the application allows you to manage employee data, including adding, updating, and deleting employee records.
+The second page provides read-only information about tribes.
+
+**Restarting the container resets the database!**

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,10 +15,13 @@ services:
       - DB_DATABASE=employees
       - DB_USER=root
       - DB_PASSWORD=password
-    command: npm start
+    command: sh -c "npm run db:setup && npm start"
     depends_on:
-      - mysql
-      - redis
+      # Run healthchecks to ensure services are started
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       - employees-network
   mysql:
@@ -28,6 +31,13 @@ services:
       - 3306:3306
     environment:
       - MYSQL_ROOT_PASSWORD=password
+    # Make sure mysql is running and connected before starting server and running db scripts
+    # Basically wait for it to respond to the ping
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$$MYSQL_ROOT_PASSWORD"]
+      interval: 5s
+      timeout: 20s
+      retries: 10
     networks:
       - employees-network
   redis:

--- a/server/src/db/scripts/create-db.ts
+++ b/server/src/db/scripts/create-db.ts
@@ -11,9 +11,21 @@ async function createDatabase() {
   knexConfig.connection.database = undefined;
 
   const knexInstance = knex(knexConfig);
-  await knexInstance.raw(`CREATE DATABASE ${dbName}`);
 
-  console.log("✅ Database created");
+  // Check if the database exists
+  const exists = await knexInstance
+    .select(knexInstance.raw("SCHEMA_NAME"))
+    .from("information_schema.SCHEMATA")
+    .where("SCHEMA_NAME", dbName);
+
+  if (exists.length === 0) {
+    // If database doesn't exist, create it
+    await knexInstance.raw(`CREATE DATABASE ${dbName}`);
+    console.log("✅ Database created");
+  } else {
+    console.log("❌ Database already exists");
+  }
+
   process.exit(0);
 }
 

--- a/server/src/db/scripts/migrate-db.ts
+++ b/server/src/db/scripts/migrate-db.ts
@@ -2,6 +2,8 @@ import getKnexInstance from "../knex";
 
 async function migrateDatabase() {
   const knexInstance = getKnexInstance();
+  // Drop tables before migrating data to reset db to initial state on every startup
+  await knexInstance.migrate.down();
   await knexInstance.migrate.up();
 
   console.log("✅ Database migrated");


### PR DESCRIPTION
docker compose up waits for mysql to be running and then runs "npm run db:setup"
Server checks that if database already exists and creates it if not. Database tables are dropped and recreated on every restart